### PR TITLE
Make Home page the default landing view

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,25 @@
+"""Streamlit entrypoint delegating to the Home page."""
+
+from importlib import import_module
+
 import streamlit as st
 
-st.title("🎈 My new app")
-st.write(
-    "Let's start building! For help and inspiration, head over to [docs.streamlit.io](https://docs.streamlit.io/)."
-)
+
+def main() -> None:
+    """Render the Home page when the app entrypoint is loaded."""
+
+    try:
+        home_module = import_module("Home")
+    except ModuleNotFoundError:
+        st.error("Home page module not found.")
+        return
+
+    if not hasattr(home_module, "main"):
+        st.error("Home page is missing a main() function.")
+        return
+
+    home_module.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update the Streamlit entrypoint to delegate rendering to the Home page module
- add helpful error messages if the Home module or its main() function are missing

## Testing
- python -m compileall streamlit_app.py Home.py

------
https://chatgpt.com/codex/tasks/task_e_68d6dc7f9e1c83218766186f0adaf46d