### PR TITLE
Document and normalize GitHub secrets configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,20 @@ A simple Streamlit app template for you to modify!
 When deploying on Streamlit Cloud, define the following entries in the **Secrets** manager:
 
 ```toml
-[secrets]
-github_token = "<your-personal-access-token>"
-github_repo = "<owner>/<repository>"
-github_branch = "<branch-name>"
-github_file_path = "<path/to/file.json>"
+[github]
+token = "<your-personal-access-token>"
+repo = "<owner>/<repository>"
+branch = "<branch-name>"  # optional, defaults to "main"
+path = "<path/to/file.json>"  # optional, defaults to "form_schema.json"
+
 editor_password_hash = "<sha256-hex-digest>"
 ```
 
-- **`github_token`** — A GitHub personal access token with the `repo:contents` and `pull_request` scopes so the app can read the form schema and open pull requests with updates.
-- **`github_repo`**, **`github_branch`**, **`github_file_path`** — Identify the repository, branch, and file that hold the schema the app reads from (and writes back to).
+- **`github.token`** — A GitHub personal access token with the `repo:contents` and `pull_request` scopes so the app can read the form schema and open pull requests with updates.
+- **`github.repo`**, **`github.branch`**, **`github.path`** — Identify the repository, branch, and file that hold the schema the app reads from (and writes back to). Only `repo` is required; the other keys fall back to sensible defaults when omitted.
 - **`editor_password_hash`** — The SHA-256 hash of the password required to edit content inside the app.
+
+For backwards compatibility the application also understands the previous flat keys (`github_token`, `github_repo`, `github_branch`, `github_file_path`, and `github_api_url`). Streamlit Cloud merges entries defined at the top level with nested sections, so you can continue using the older naming convention if you already have it saved.
 
 Generate the password hash with a one-liner such as:
 

--- a/pages/02_Editor.py
+++ b/pages/02_Editor.py
@@ -23,15 +23,31 @@ LIST_OPERATORS = {"in", "not_in", "contains_any", "contains_all", "one_of"}
 PREVIEW_ANSWERS_STATE_KEY = "editor_preview_answers"
 
 
+def _secrets_dict(name: str) -> Dict[str, Any]:
+    """Return a mapping stored under ``name`` in Streamlit secrets."""
+
+    value = st.secrets.get(name, {})  # type: ignore[arg-type]
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
 def get_github_config() -> Optional[Dict[str, Any]]:
     """Return GitHub configuration from Streamlit secrets if available."""
 
-    secrets = st.secrets.get("github", {})  # type: ignore[arg-type]
+    secrets = _secrets_dict("github")
     token = secrets.get("token")
     repo = secrets.get("repo")
     path = secrets.get("path", "form_schema.json")
     branch = secrets.get("branch", "main")
     api_url = secrets.get("api_url", "https://api.github.com")
+
+    if not (token and repo and path):
+        token = st.secrets.get("github_token", token)
+        repo = st.secrets.get("github_repo", repo)
+        path = st.secrets.get("github_file_path", path)
+        branch = st.secrets.get("github_branch", branch)
+        api_url = st.secrets.get("github_api_url", api_url)
 
     if token and repo and path:
         return {


### PR DESCRIPTION
## Summary
- document the expected Streamlit secrets structure for GitHub access
- normalise GitHub secret loading to support both nested and legacy flat keys

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d6e0a9a9308321809222c21d7c93f0