### PR TITLE
Support contains_any operator in show rules

### DIFF
--- a/pages/01_Questionnaire.py
+++ b/pages/01_Questionnaire.py
@@ -121,6 +121,19 @@ def eval_clause(clause: Dict[str, Any], answers: Dict[str, Any]) -> bool:
         if not isinstance(expected, Sequence) or isinstance(expected, str):
             return False
         return any(item in value for item in expected)
+    if operator == "contains_any":
+        if expected is None:
+            return False
+        if isinstance(expected, Sequence) and not isinstance(expected, str):
+            expected_values = list(expected)
+        else:
+            expected_values = [expected]
+
+        if isinstance(value, str):
+            return any(isinstance(item, str) and item in value for item in expected_values)
+        if isinstance(value, Sequence) and not isinstance(value, str):
+            return any(item in value for item in expected_values)
+        return False
     if operator == "all_selected":
         if not isinstance(value, Sequence) or isinstance(value, str):
             return False

--- a/pages/02_Editor.py
+++ b/pages/02_Editor.py
@@ -353,6 +353,19 @@ def eval_clause(clause: Dict[str, Any], answers: Dict[str, Any]) -> bool:
         if not isinstance(expected, Sequence) or isinstance(expected, str):
             return False
         return any(item in value for item in expected)
+    if operator == "contains_any":
+        if expected is None:
+            return False
+        if isinstance(expected, Sequence) and not isinstance(expected, str):
+            expected_values = list(expected)
+        else:
+            expected_values = [expected]
+
+        if isinstance(value, str):
+            return any(isinstance(item, str) and item in value for item in expected_values)
+        if isinstance(value, Sequence) and not isinstance(value, str):
+            return any(item in value for item in expected_values)
+        return False
     if operator == "all_selected":
         if not isinstance(value, Sequence) or isinstance(value, str):
             return False


### PR DESCRIPTION
## Summary
- add contains_any evaluation support in the questionnaire renderer
- mirror contains_any evaluation in the editor preview logic

## Testing
- python -m compileall pages

------
https://chatgpt.com/codex/tasks/task_e_68db915c96488321800dcc40f9e89eec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “contains any” condition to Questionnaire and Editor conditional logic.
  * Supports text (substring matches) and list fields (any item match).
  * Accepts single or multiple expected values for more flexible rules.
  * Enhances filters, branching, and dynamic visibility/validation behavior without affecting existing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->