### PR TITLE
docs: add troubleshooting guidance for GitHub configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,28 @@ A simple Streamlit app template for you to modify!
 When deploying on Streamlit Cloud, define the following entries in the **Secrets** manager:
 
 ```toml
+editor_password_hash = "<sha256-hex-digest>"
+
 [github]
 token = "<your-personal-access-token>"
 repo = "<owner>/<repository>"
 branch = "<branch-name>"  # optional, defaults to "main"
 path = "<path/to/file.json>"  # optional, defaults to "form_schema.json"
-
-editor_password_hash = "<sha256-hex-digest>"
 ```
 
 - **`github.token`** — A GitHub personal access token with the `repo:contents` and `pull_request` scopes so the app can read the form schema and open pull requests with updates.
 - **`github.repo`**, **`github.branch`**, **`github.path`** — Identify the repository, branch, and file that hold the schema the app reads from (and writes back to). Only `repo` is required; the other keys fall back to sensible defaults when omitted.
 - **`editor_password_hash`** — The SHA-256 hash of the password required to edit content inside the app.
+
+### Troubleshooting “GitHub not configured”
+
+If you see a banner stating that GitHub is not configured when you try to publish or save a draft, double-check the following:
+
+1. **Secrets formatting** — The `[github]` table must contain at least `token` and `repo`. Optional values include `branch`, `path`, and `api_url`. The `editor_password_hash` entry belongs at the **top level** of your `secrets.toml`, not inside the `[github]` block.
+2. **Personal access token scopes** — The token needs `repo` access (or, for public repositories, the more granular `contents` scope plus `pull_request`). Without the correct scopes GitHub API calls will fail.
+3. **Streamlit restart** — Secrets are cached in deployed apps. After editing them, stop and restart the Streamlit session so the new values are picked up.
+
+When secrets are missing the editor falls back to saving `form_schema.json` locally, which triggers the “GitHub not configured” message you are seeing. Once the required entries are present the editor will push commits and pull requests to the configured repository instead of writing to the local file.
 
 For backwards compatibility the application also understands the previous flat keys (`github_token`, `github_repo`, `github_branch`, `github_file_path`, and `github_api_url`). Streamlit Cloud merges entries defined at the top level with nested sections, so you can continue using the older naming convention if you already have it saved.
 


### PR DESCRIPTION
## Summary
- clarify that `editor_password_hash` must be defined at the top level of `secrets.toml`
- add troubleshooting steps for the “GitHub not configured” banner in the editor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db99d0f0848321a5e2e72b229ba40c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified secrets configuration, placing the editor_password_hash at the top level and noting backward compatibility with older keys.
  * Added a “GitHub not configured” troubleshooting section covering required token scopes, secrets formatting, restart guidance after updating secrets, and fallback behavior with steps to enable GitHub pushes.
  * Included a one-line example for generating a password hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->