### PR TITLE
Fix Streamlit secrets parsing for GitHub config

### DIFF
--- a/pages/01_Questionnaire.py
+++ b/pages/01_Questionnaire.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from html import escape as html_escape
 from typing import Any, Dict, List, Optional, Sequence
@@ -38,7 +39,7 @@ def _secrets_dict(name: str) -> Dict[str, Any]:
     """Return a mapping stored under ``name`` in Streamlit secrets."""
 
     value = st.secrets.get(name, {})  # type: ignore[arg-type]
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         return dict(value)
     return {}
 

--- a/pages/02_Editor.py
+++ b/pages/02_Editor.py
@@ -7,6 +7,7 @@ import hmac
 import json
 from copy import deepcopy
 from datetime import datetime
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Sequence
 
 import streamlit as st
@@ -38,7 +39,7 @@ def _secrets_dict(name: str) -> Dict[str, Any]:
     """Return a mapping stored under ``name`` in Streamlit secrets."""
 
     value = st.secrets.get(name, {})  # type: ignore[arg-type]
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         return dict(value)
     return {}
 


### PR DESCRIPTION
## Summary
- treat Streamlit secrets objects as mappings when reading GitHub configuration in the questionnaire and editor pages
- ensure nested secrets from Streamlit Cloud are converted to dictionaries before use

## Testing
- python -m compileall pages

------
https://chatgpt.com/codex/tasks/task_e_68dbad355cec8321bedd1ad6017494ee