### PR TITLE
Support multiple questionnaires with new system registration page

### DIFF
--- a/form_schema.json
+++ b/form_schema.json
@@ -4,159 +4,197 @@
     "status": "published",
     "published_at": "2024-01-15T10:30:00Z"
   },
-  "page": {
-    "title": "Assessment",
-    "show_introduction": true,
-    "introduction": {
-      "heading": "\ud83d\udc4b Welcome!",
-      "paragraphs": [
-        "Please answer the questions below so we can tailor the experience to you.",
-        "Questions may appear or disappear automatically depending on your responses."
-      ]
-    },
-    "show_debug_answers": true,
-    "debug_expander_label": "Debug: current answers",
-    "submit": {
-      "label": "Submit questionnaire",
-      "success_message": "Responses captured. Persistence will be wired via GitHub.",
-      "show_answers_summary": true
-    }
-  },
-  "questions": [
-    {
-      "key": "q_area",
-      "label": "Select your area",
-      "type": "single",
-      "options": [
-        "Research",
-        "HR",
-        "IT"
-      ]
-    },
-    {
-      "key": "q_handles_personal_data",
-      "label": "Do you handle personal data?",
-      "type": "single",
-      "options": [
-        "Yes",
-        "No"
-      ]
-    },
-    {
-      "key": "q_sensitive_categories",
-      "label": "Which sensitive categories are involved?",
-      "type": "multiselect",
-      "options": [
-        "Health",
-        "Biometric",
-        "Financial"
-      ],
-      "show_if": {
-        "all": [
-          {
-            "field": "q_handles_personal_data",
-            "operator": "equals",
-            "value": "Yes"
-          }
-        ]
-      }
-    },
-    {
-      "key": "use-AI",
-      "label": "Is your solution using AI?",
-      "type": "single",
-      "options": [
-        "Yes",
-        "No"
-      ]
-    },
-    {
-      "key": "high-risk",
-      "label": "Is AI used in any of the following ways?",
-      "type": "multiselect",
-      "options": [
-        "Biometric categorization",
-        "Biometric identification",
-        "Recruitment",
-        "Employee management"
-      ],
-      "show_if": {
-        "all": [
-          {
-            "field": "use-AI",
-            "operator": "equals",
-            "value": "Yes"
-          }
-        ]
-      }
-    },
-    {
-      "key": "rd-exception",
-      "label": "Is the AI developed only for R&D?",
-      "type": "single",
-      "options": [
-        "Yes",
-        "No"
-      ],
-      "show_if": {
-        "all": [
-          {
-            "operator": "includes",
-            "field": "q_area",
-            "value": "Research"
-          },
-          {
-            "operator": "equals",
-            "field": "use-AI",
-            "value": "Yes"
-          }
-        ]
-      }
-    },
-    {
-      "key": "r_high_risk",
-      "label": "Your solution is high risk",
-      "type": "statement",
-      "show_if": {
-        "all": [
-          {
-            "any": [
+  "questionnaires": {
+    "assessment": {
+      "label": "Assessment",
+      "page": {
+        "title": "Assessment",
+        "show_introduction": true,
+        "introduction": {
+          "heading": "\ud83d\udc4b Welcome!",
+          "paragraphs": [
+            "Please answer the questions below so we can tailor the experience to you.",
+            "Questions may appear or disappear automatically depending on your responses."
+          ]
+        },
+        "show_debug_answers": true,
+        "debug_expander_label": "Debug: current answers",
+        "submit": {
+          "label": "Submit questionnaire",
+          "success_message": "Responses captured. Persistence will be wired via GitHub.",
+          "show_answers_summary": true
+        }
+      },
+      "questions": [
+        {
+          "key": "q_area",
+          "label": "Select your area",
+          "type": "single",
+          "options": [
+            "Research",
+            "HR",
+            "IT"
+          ]
+        },
+        {
+          "key": "q_handles_personal_data",
+          "label": "Do you handle personal data?",
+          "type": "single",
+          "options": [
+            "Yes",
+            "No"
+          ]
+        },
+        {
+          "key": "q_sensitive_categories",
+          "label": "Which sensitive categories are involved?",
+          "type": "multiselect",
+          "options": [
+            "Health",
+            "Biometric",
+            "Financial"
+          ],
+          "show_if": {
+            "all": [
               {
-                "operator": "contains_any",
-                "field": "high-risk",
-                "value": [
-                  "Biometric categorization",
-                  "Biometric identification",
-                  "Recruitment",
-                  "Employee management"
-                ]
-              },
-              {
-                "operator": "contains_any",
-                "field": "q_sensitive_categories",
-                "value": [
-                  "Biometric",
-                  "Health"
-                ]
-              }
-            ]
-          },
-          {
-            "any": [
-              {
-                "operator": "not_equals",
-                "field": "q_area",
-                "value": "Research"
-              },
-              {
-                "operator": "not_equals",
-                "field": "rd-exception",
+                "field": "q_handles_personal_data",
+                "operator": "equals",
                 "value": "Yes"
               }
             ]
           }
-        ]
-      }
+        },
+        {
+          "key": "use-AI",
+          "label": "Is your solution using AI?",
+          "type": "single",
+          "options": [
+            "Yes",
+            "No"
+          ]
+        },
+        {
+          "key": "high-risk",
+          "label": "Is AI used in any of the following ways?",
+          "type": "multiselect",
+          "options": [
+            "Biometric categorization",
+            "Biometric identification",
+            "Recruitment",
+            "Employee management"
+          ],
+          "show_if": {
+            "all": [
+              {
+                "field": "use-AI",
+                "operator": "equals",
+                "value": "Yes"
+              }
+            ]
+          }
+        },
+        {
+          "key": "rd-exception",
+          "label": "Is the AI developed only for R&D?",
+          "type": "single",
+          "options": [
+            "Yes",
+            "No"
+          ],
+          "show_if": {
+            "all": [
+              {
+                "operator": "includes",
+                "field": "q_area",
+                "value": "Research"
+              },
+              {
+                "operator": "equals",
+                "field": "use-AI",
+                "value": "Yes"
+              }
+            ]
+          }
+        },
+        {
+          "key": "r_high_risk",
+          "label": "Your solution is high risk",
+          "type": "statement",
+          "show_if": {
+            "all": [
+              {
+                "any": [
+                  {
+                    "operator": "contains_any",
+                    "field": "high-risk",
+                    "value": [
+                      "Biometric categorization",
+                      "Biometric identification",
+                      "Recruitment",
+                      "Employee management"
+                    ]
+                  },
+                  {
+                    "operator": "contains_any",
+                    "field": "q_sensitive_categories",
+                    "value": [
+                      "Biometric",
+                      "Health"
+                    ]
+                  }
+                ]
+              },
+              {
+                "any": [
+                  {
+                    "operator": "not_equals",
+                    "field": "q_area",
+                    "value": "Research"
+                  },
+                  {
+                    "operator": "not_equals",
+                    "field": "rd-exception",
+                    "value": "Yes"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "system_registration": {
+      "label": "System registration",
+      "page": {
+        "title": "System registration",
+        "show_introduction": true,
+        "introduction": {
+          "heading": "System registration overview",
+          "paragraphs": [
+            "This is placeholder content for the upcoming system registration questionnaire.",
+            "Update this section with the final introduction when requirements are defined."
+          ]
+        },
+        "show_debug_answers": false,
+        "debug_expander_label": "Debug: current answers",
+        "submit": {
+          "label": "Submit system registration",
+          "success_message": "System registration submitted (placeholder).",
+          "show_answers_summary": false
+        }
+      },
+      "questions": [
+        {
+          "key": "system-type",
+          "label": "Which system type are you registering?",
+          "type": "single",
+          "options": [
+            "Placeholder option A",
+            "Placeholder option B",
+            "Placeholder option C"
+          ]
+        }
+      ]
     }
-  ]
+  }
 }

--- a/lib/questionnaire_utils.py
+++ b/lib/questionnaire_utils.py
@@ -1,0 +1,91 @@
+"""Utilities for working with multi-questionnaire schemas."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Tuple
+
+DEFAULT_QUESTIONNAIRE_KEY = "assessment"
+EDITOR_SELECTED_STATE_KEY = "editor_selected_questionnaire"
+RUNNER_SELECTED_STATE_KEY = "runner_selected_questionnaire"
+
+
+def _ensure_mapping(value: Any) -> Dict[str, Any]:
+    """Return ``value`` if it is a mapping, otherwise an empty dict."""
+
+    return value if isinstance(value, dict) else {}
+
+
+def _ensure_sequence(value: Any) -> List[Dict[str, Any]]:
+    """Return ``value`` if it is a list, otherwise an empty list."""
+
+    return value if isinstance(value, list) else []
+
+
+def _derive_label(key: str, payload: Dict[str, Any]) -> str:
+    """Return a human-friendly label for a questionnaire entry."""
+
+    label = payload.get("label")
+    if isinstance(label, str) and label.strip():
+        return label.strip()
+
+    page = _ensure_mapping(payload.get("page"))
+    title = page.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+
+    return key.replace("_", " ").title() if key else "Questionnaire"
+
+
+def normalize_questionnaires(schema: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Ensure ``schema`` exposes a ``questionnaires`` mapping with defaults."""
+
+    if not isinstance(schema, dict):
+        return {}
+
+    questionnaires = schema.get("questionnaires")
+    if not isinstance(questionnaires, dict) or not questionnaires:
+        page_settings = _ensure_mapping(schema.get("page"))
+        questions = _ensure_sequence(schema.get("questions"))
+        questionnaires = {
+            DEFAULT_QUESTIONNAIRE_KEY: {
+                "label": _derive_label(DEFAULT_QUESTIONNAIRE_KEY, {"page": page_settings}),
+                "page": page_settings,
+                "questions": questions,
+            }
+        }
+
+    normalised: Dict[str, Dict[str, Any]] = {}
+    for key, payload in questionnaires.items():
+        entry = _ensure_mapping(payload).copy()
+        entry["page"] = _ensure_mapping(entry.get("page"))
+        entry["questions"] = _ensure_sequence(entry.get("questions"))
+        entry["label"] = _derive_label(key, entry)
+        normalised[str(key)] = entry
+
+    schema["questionnaires"] = normalised
+    schema.pop("page", None)
+    schema.pop("questions", None)
+    return normalised
+
+
+def questionnaire_choices(schema: Dict[str, Any]) -> List[Tuple[str, str]]:
+    """Return ``(key, label)`` pairs for all questionnaires in ``schema``."""
+
+    questionnaires = normalize_questionnaires(schema)
+    return [(key, entry.get("label", key)) for key, entry in questionnaires.items()]
+
+
+def get_questionnaire(schema: Dict[str, Any], key: str) -> Dict[str, Any]:
+    """Return the questionnaire entry identified by ``key``."""
+
+    questionnaires = normalize_questionnaires(schema)
+    if key in questionnaires:
+        return questionnaires[key]
+    return questionnaires[next(iter(questionnaires))]
+
+
+def iter_questionnaires(schema: Dict[str, Any]) -> Iterable[Tuple[str, Dict[str, Any]]]:
+    """Yield ``(key, questionnaire)`` tuples for the schema."""
+
+    questionnaires = normalize_questionnaires(schema)
+    return questionnaires.items()


### PR DESCRIPTION
## Summary
- reorganize the schema around named questionnaires and add a placeholder system registration form
- let visitors choose which questionnaire to run from the home page and questionnaire view, keeping answers scoped per form
- update the editor to switch between questionnaires, normalise state, and save the expanded schema structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbdf45fc90832187a14d23d65ce773