### PR TITLE
Replace deprecated Streamlit query param API

### DIFF
--- a/pages/01_Questionnaire.py
+++ b/pages/01_Questionnaire.py
@@ -205,7 +205,7 @@ def should_show_question(question: Dict[str, Any], answers: Dict[str, Any]) -> b
 def _get_query_param(name: str) -> Optional[str]:
     """Return the first query parameter value if present."""
 
-    params = st.experimental_get_query_params()
+    params = st.query_params
     values = params.get(name)
     if not values:
         return None
@@ -217,9 +217,8 @@ def _get_query_param(name: str) -> Optional[str]:
 def _set_query_param(name: str, value: str) -> None:
     """Persist ``value`` in the query string under ``name``."""
 
-    params = st.experimental_get_query_params()
+    params = st.query_params
     params[name] = value
-    st.experimental_set_query_params(**params)
 
 
 def render_question(


### PR DESCRIPTION
## Summary
- replace `st.experimental_get_query_params` with the stable `st.query_params`
- update query parameter setter to use the new API while preserving existing behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe7699924832182cd3112e3eae71b