### PR TITLE
Handle questionnaire utils flag import gracefully

### DIFF
--- a/lib/form_store.py
+++ b/lib/form_store.py
@@ -3,10 +3,29 @@
 from __future__ import annotations
 
 import json
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Tuple
 
-from lib.questionnaire_utils import MULTI_FORM_FLAG
+
+def _load_multi_form_flag() -> str:
+    """Return the multi-form flag constant from ``questionnaire_utils``.
+
+    The Streamlit execution environment can import the modules in ``lib`` in
+    slightly different orders which, in rare cases, results in
+    ``questionnaire_utils`` being partially initialised when ``form_store``
+    tries to import ``MULTI_FORM_FLAG``. Attempting ``from module import
+    name`` during that window raises ``ImportError`` even though the module is
+    available. To make ``form_store`` resilient we import the module directly
+    and fall back to the known constant if the attribute is temporarily
+    unavailable.
+    """
+
+    module = import_module("lib.questionnaire_utils")
+    return getattr(module, "MULTI_FORM_FLAG", "_multi_form")
+
+
+MULTI_FORM_FLAG = _load_multi_form_flag()
 
 FORM_SCHEMA_FILENAME = "form_schema.json"
 SCHEMAS_ROOT = Path("form_schemas")

--- a/tests/test_form_store.py
+++ b/tests/test_form_store.py
@@ -1,0 +1,36 @@
+"""Tests for the questionnaire form store helpers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _reload_form_store():
+    """Return a freshly reloaded ``lib.form_store`` module."""
+
+    module = importlib.import_module("lib.form_store")
+    return importlib.reload(module)
+
+
+def test_multi_form_flag_matches_questionnaire_constant():
+    """``form_store`` should expose the flag defined in ``questionnaire_utils``."""
+
+    form_store = _reload_form_store()
+    questionnaire_utils = importlib.import_module("lib.questionnaire_utils")
+    assert form_store.MULTI_FORM_FLAG == questionnaire_utils.MULTI_FORM_FLAG
+
+
+def test_multi_form_flag_fallback_when_missing(monkeypatch):
+    """Fallback to the default constant when the attribute is unavailable."""
+
+    stub_module = types.ModuleType("questionnaire_utils")
+    monkeypatch.setitem(sys.modules, "lib.questionnaire_utils", stub_module)
+
+    form_store = _reload_form_store()
+    assert form_store.MULTI_FORM_FLAG == "_multi_form"
+
+    # Restore the original module for any subsequent imports during the test run.
+    monkeypatch.undo()
+    _reload_form_store()


### PR DESCRIPTION
## Summary
- load the multi-form flag via a helper that tolerates partially initialised imports
- cover the new behaviour with unit tests that exercise the fallback path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbf54d45688321b278f8dba7c42874