### PR TITLE
Add related record question type with repository selection

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,8 @@
+"""Library helpers for the assessment questionnaire application."""
+
+from .related_records import (  # noqa: F401
+    RELATED_RECORD_SOURCES,
+    SOURCE_DIRECTORIES,
+    load_related_record_options,
+    related_record_source_label,
+)

--- a/lib/related_records.py
+++ b/lib/related_records.py
@@ -1,0 +1,89 @@
+"""Utilities for referencing stored questionnaire submissions as related records."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+RELATED_RECORD_SOURCES: Dict[str, str] = {
+    "system_registration": "Registered systems",
+    "assessment": "Assessment submissions",
+}
+
+SOURCE_DIRECTORIES: Dict[str, Path] = {
+    "system_registration": PROJECT_ROOT / "system_registration" / "submissions",
+    "assessment": PROJECT_ROOT / "assessment" / "submissions",
+}
+
+
+def related_record_source_label(source: str) -> str:
+    """Return a human-friendly label for a related record ``source``."""
+
+    return RELATED_RECORD_SOURCES.get(source, source or "Unknown source")
+
+
+def _parse_timestamp(value: Any) -> Tuple[str, float]:
+    """Normalise an ISO timestamp string, returning text and a sort key."""
+
+    if isinstance(value, str) and value.strip():
+        raw = value.strip()
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            return raw, 0.0
+        return parsed.isoformat(), parsed.timestamp()
+    return "", 0.0
+
+
+def _iter_submission_files(directory: Path) -> Iterable[Path]:
+    """Yield submission files stored inside ``directory`` in a stable order."""
+
+    if not directory.exists():
+        return []
+    return sorted(directory.glob("*.json"))
+
+
+def load_related_record_options(source: str) -> List[Tuple[str, str]]:
+    """Return ``(value, label)`` pairs for submissions from ``source``.
+
+    The function de-duplicates submissions by identifier, preferring the most
+    recent entry based on the ``submitted_at`` timestamp when available.
+    """
+
+    directory = SOURCE_DIRECTORIES.get(source)
+    if directory is None:
+        return []
+
+    records: Dict[str, Tuple[str, str, float]] = {}
+
+    for submission_file in _iter_submission_files(directory):
+        try:
+            with submission_file.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        submission_id = str(payload.get("id") or submission_file.stem)
+        timestamp_text, sort_key = _parse_timestamp(payload.get("submitted_at"))
+        label = submission_id if not timestamp_text else f"{submission_id} · {timestamp_text}"
+
+        existing = records.get(submission_id)
+        if existing is None or sort_key > existing[2]:
+            records[submission_id] = (submission_id, label, sort_key)
+
+    entries = list(records.values())
+    entries.sort(key=lambda item: (-item[2], item[0]))
+
+    return [(identifier, label) for identifier, label, _ in entries]
+
+
+__all__ = [
+    "RELATED_RECORD_SOURCES",
+    "SOURCE_DIRECTORIES",
+    "load_related_record_options",
+    "related_record_source_label",
+]

--- a/tests/test_related_records.py
+++ b/tests/test_related_records.py
@@ -1,0 +1,62 @@
+"""Tests for the related record helper utilities."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _write_submission(path: Path, identifier: str, submitted_at: datetime | None) -> None:
+    payload = {
+        "id": identifier,
+        "questionnaire_key": "test",
+        "answers": {},
+    }
+    if submitted_at is not None:
+        payload["submitted_at"] = submitted_at.isoformat()
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+
+
+def test_load_related_record_options_returns_sorted_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory = tmp_path / "system_registration" / "submissions"
+    directory.mkdir(parents=True)
+
+    newer_time = datetime(2024, 5, 1, tzinfo=timezone.utc)
+    older_time = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    _write_submission(directory / "first.json", "abc", older_time)
+    _write_submission(directory / "second.json", "xyz", newer_time)
+    # Duplicate ID with a newer timestamp should replace the older entry
+    _write_submission(directory / "duplicate.json", "abc", newer_time)
+
+    related_records = importlib.import_module("lib.related_records")
+    monkeypatch.setattr(
+        related_records,
+        "SOURCE_DIRECTORIES",
+        {"system_registration": directory},
+        raising=False,
+    )
+
+    options = related_records.load_related_record_options("system_registration")
+
+    assert options == [
+        ("abc", f"abc · {newer_time.isoformat()}"),
+        ("xyz", f"xyz · {newer_time.isoformat()}"),
+    ]
+
+
+def test_related_record_source_label_has_fallback() -> None:
+    related_records = importlib.import_module("lib.related_records")
+    assert (
+        related_records.related_record_source_label("system_registration")
+        == related_records.RELATED_RECORD_SOURCES["system_registration"]
+    )
+    assert related_records.related_record_source_label("unknown-source") == "unknown-source"
+    assert related_records.related_record_source_label("") == "Unknown source"


### PR DESCRIPTION
## Summary
- add utilities to surface related records from stored submissions
- update the questionnaire runner and editor to support a related record question type
- cover the new helper logic with dedicated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc0d6aa3c88321aa8c1be612985d29