### PR TITLE
Fix questionnaire constant import race

### DIFF
--- a/lib/questionnaire_utils.py
+++ b/lib/questionnaire_utils.py
@@ -2,6 +2,20 @@
 
 from __future__ import annotations
 
+# NOTE:
+# Keep the constant definitions at the top of the module. Streamlit sometimes
+# triggers overlapping imports from multiple threads which can observe this
+# module before it has finished initialising. Defining the constants before any
+# other imports ensures they are already present on ``sys.modules`` so ``from
+# lib.questionnaire_utils import NAME`` succeeds even during that window.
+DEFAULT_QUESTIONNAIRE_KEY = "assessment"
+MULTI_FORM_FLAG = "_multi_form"
+EDITOR_SELECTED_STATE_KEY = "editor_selected_questionnaire"
+RUNNER_SELECTED_STATE_KEY = "runner_selected_questionnaire"
+RECORD_NAME_FIELD = "_record_name"
+RECORD_NAME_KEY = "record_name"
+RECORD_NAME_TYPE = "record_name"
+
 from typing import Any, Dict, Iterable, List, Tuple
 
 __all__ = [
@@ -18,14 +32,6 @@ __all__ = [
     "iter_questionnaires",
     "extract_record_name",
 ]
-
-DEFAULT_QUESTIONNAIRE_KEY = "assessment"
-MULTI_FORM_FLAG = "_multi_form"
-EDITOR_SELECTED_STATE_KEY = "editor_selected_questionnaire"
-RUNNER_SELECTED_STATE_KEY = "runner_selected_questionnaire"
-RECORD_NAME_FIELD = "_record_name"
-RECORD_NAME_KEY = "record_name"
-RECORD_NAME_TYPE = "record_name"
 
 
 def _ensure_mapping(value: Any) -> Dict[str, Any]:

--- a/tests/test_questionnaire_utils.py
+++ b/tests/test_questionnaire_utils.py
@@ -36,3 +36,31 @@ def test_extract_record_name_handles_missing_values() -> None:
     answers = {}
 
     assert utils.extract_record_name(questionnaire, answers) == ""
+
+
+def test_constants_available_while_module_initialises(monkeypatch) -> None:
+    """Importing the module exposes constants even before other imports."""
+
+    import sys
+    import builtins
+    import importlib
+
+    sys.modules.pop("lib.questionnaire_utils", None)
+
+    real_import = builtins.__import__
+
+    def intercept(name, globals=None, locals=None, fromlist=(), level=0):  # type: ignore[override]
+        module_name = globals.get("__name__") if globals else None
+        if module_name == "lib.questionnaire_utils" and name == "typing":
+            module = sys.modules.get("lib.questionnaire_utils")
+            assert module is not None
+            assert getattr(module, "DEFAULT_QUESTIONNAIRE_KEY", None) == "assessment"
+            assert getattr(module, "MULTI_FORM_FLAG", None) == "_multi_form"
+            assert getattr(module, "RECORD_NAME_FIELD", None) == "_record_name"
+            assert getattr(module, "RECORD_NAME_KEY", None) == "record_name"
+            assert getattr(module, "RECORD_NAME_TYPE", None) == "record_name"
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", intercept)
+
+    importlib.import_module("lib.questionnaire_utils")


### PR DESCRIPTION
## Summary
- move questionnaire constant definitions ahead of other imports so they are visible during module initialisation
- document the import-order requirement and add a regression test that checks constants are exposed while the module loads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dc24686ef48321bb041b79c7183ebf