### PR TITLE
Handle missing record name constants gracefully

### DIFF
--- a/pages/01_Questionnaire.py
+++ b/pages/01_Questionnaire.py
@@ -21,15 +21,20 @@ from lib.form_store import (
     resolve_remote_form_path,
 )
 from lib.github_backend import GitHubBackend
-from lib.questionnaire_utils import (
-    DEFAULT_QUESTIONNAIRE_KEY,
-    RECORD_NAME_FIELD,
-    RECORD_NAME_KEY,
-    RECORD_NAME_TYPE,
-    RUNNER_SELECTED_STATE_KEY,
-    extract_record_name,
-    normalize_questionnaires,
-)
+import lib.questionnaire_utils as questionnaire_utils
+
+DEFAULT_QUESTIONNAIRE_KEY = questionnaire_utils.DEFAULT_QUESTIONNAIRE_KEY
+RUNNER_SELECTED_STATE_KEY = questionnaire_utils.RUNNER_SELECTED_STATE_KEY
+extract_record_name = questionnaire_utils.extract_record_name
+normalize_questionnaires = questionnaire_utils.normalize_questionnaires
+
+# ``RECORD_NAME_FIELD`` and related constants were added in tandem with this page,
+# but older deployments may still import a version of ``questionnaire_utils``
+# that predates them. ``getattr`` keeps the page working with those builds
+# instead of failing with an ``ImportError`` when the constants are missing.
+RECORD_NAME_FIELD = getattr(questionnaire_utils, "RECORD_NAME_FIELD", "_record_name")
+RECORD_NAME_KEY = getattr(questionnaire_utils, "RECORD_NAME_KEY", "record_name")
+RECORD_NAME_TYPE = getattr(questionnaire_utils, "RECORD_NAME_TYPE", "record_name")
 from lib.related_records import (
     RELATED_RECORD_SOURCES,
     load_related_record_options,

--- a/pages/02_Editor.py
+++ b/pages/02_Editor.py
@@ -21,12 +21,16 @@ if str(PROJECT_ROOT) not in sys.path:
 from Home import load_schema
 from lib.github_backend import GitHubBackend, create_branch, ensure_pr, put_file
 from lib.form_store import load_combined_schema, local_form_path, resolve_remote_form_path
-from lib.questionnaire_utils import (
-    EDITOR_SELECTED_STATE_KEY,
-    RECORD_NAME_FIELD,
-    RECORD_NAME_TYPE,
-    normalize_questionnaires,
-)
+import lib.questionnaire_utils as questionnaire_utils
+
+EDITOR_SELECTED_STATE_KEY = questionnaire_utils.EDITOR_SELECTED_STATE_KEY
+normalize_questionnaires = questionnaire_utils.normalize_questionnaires
+
+# ``RECORD_NAME_FIELD`` and ``RECORD_NAME_TYPE`` are new additions. Older
+# ``questionnaire_utils`` modules won't define them which used to crash the page
+# during import. ``getattr`` keeps the editor working with those deployments.
+RECORD_NAME_FIELD = getattr(questionnaire_utils, "RECORD_NAME_FIELD", "_record_name")
+RECORD_NAME_TYPE = getattr(questionnaire_utils, "RECORD_NAME_TYPE", "record_name")
 from lib.related_records import (
     RELATED_RECORD_SOURCES,
     load_related_record_options,


### PR DESCRIPTION
## Summary
- import the questionnaire utilities module directly on the questionnaire and editor pages
- provide default values for record name constants so older questionnaire_utils versions do not break imports

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc293ece848321885bbbaa94349706