### PR TITLE
Handle missing RECORD_NAME_KEY constant

### DIFF
--- a/pages/03_Registered_Systems.py
+++ b/pages/03_Registered_Systems.py
@@ -9,7 +9,9 @@ from typing import Any, Dict, Iterable, List, Tuple
 
 import streamlit as st
 
-from lib.questionnaire_utils import RECORD_NAME_KEY
+from lib import questionnaire_utils
+
+RECORD_NAME_KEY = getattr(questionnaire_utils, "RECORD_NAME_KEY", "record_name")
 
 SUBMISSIONS_DIR = Path("system_registration/submissions")
 DEFAULT_TABLE_COLUMNS = ("Submission ID", "Submitted at", "Questionnaire")

--- a/pages/04_Assessment_Submissions.py
+++ b/pages/04_Assessment_Submissions.py
@@ -14,7 +14,9 @@ if str(PROJECT_ROOT) not in sys.path:
 
 import streamlit as st
 
-from lib.questionnaire_utils import RECORD_NAME_KEY
+from lib import questionnaire_utils
+
+RECORD_NAME_KEY = getattr(questionnaire_utils, "RECORD_NAME_KEY", "record_name")
 
 SUBMISSIONS_DIR = Path("assessment/submissions")
 DEFAULT_TABLE_COLUMNS = ("Submission ID", "Submitted at", "Questionnaire")


### PR DESCRIPTION
## Summary
- update the registered systems and assessment submissions pages to import questionnaire utilities safely
- fall back to a default record name key when the constant is unavailable to avoid runtime import errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc39c730d8832190c8f5f94c8060c3