### PR TITLE
Refresh Streamlit styling and shared theme

### DIFF
--- a/lib/ui_theme.py
+++ b/lib/ui_theme.py
@@ -1,0 +1,354 @@
+"""Utilities for applying a shared visual identity across Streamlit pages."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import streamlit as st
+
+
+_THEME_CSS = """
+<style>
+:root {
+    --app-accent: #5145CD;
+    --app-accent-dark: #4338CA;
+    --app-accent-soft: #E8E7FB;
+    --app-surface: rgba(255, 255, 255, 0.92);
+    --app-surface-strong: #FFFFFF;
+    --app-border: rgba(81, 69, 205, 0.25);
+    --app-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    --app-text: #1F2933;
+    --app-muted: #52606D;
+    --app-success: #059669;
+    --app-warning: #B45309;
+    --app-error: #DC2626;
+}
+
+html, body {
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    color: var(--app-text);
+}
+
+[data-testid="stAppViewContainer"] {
+    background: radial-gradient(circle at top right, #F4F2FF 0%, #EEF2FF 35%, #FFFFFF 75%);
+}
+
+[data-testid="stHeader"] {
+    background: rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(18px);
+    border-bottom: 1px solid rgba(81, 69, 205, 0.1);
+}
+
+[data-testid="stSidebar"] {
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(18px);
+    border-right: 1px solid rgba(81, 69, 205, 0.12);
+}
+
+.block-container {
+    padding-top: 2.5rem;
+    padding-bottom: 4rem;
+}
+
+.app-header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1.75rem 2rem;
+    background: var(--app-surface);
+    border-radius: 1.75rem;
+    border: 1px solid rgba(81, 69, 205, 0.18);
+    box-shadow: var(--app-shadow);
+    margin-bottom: 2rem;
+}
+
+.app-header__icon {
+    font-size: 2.75rem;
+    line-height: 1;
+}
+
+.app-header__title {
+    margin: 0;
+    font-size: 2.25rem;
+    font-weight: 700;
+    color: var(--app-text);
+}
+
+.app-header__subtitle {
+    margin: 0.25rem 0 0 0;
+    font-size: 1.05rem;
+    color: var(--app-muted);
+}
+
+.app-card {
+    background: var(--app-surface-strong);
+    border-radius: 1.5rem;
+    border: 1px solid rgba(81, 69, 205, 0.12);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.07);
+    padding: 1.75rem 2rem;
+    margin-bottom: 1.5rem;
+}
+
+.app-card__title {
+    margin: 0 0 1rem 0;
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: var(--app-text);
+}
+
+.app-card p {
+    color: var(--app-muted);
+    font-size: 1.02rem;
+    line-height: 1.55;
+    margin-bottom: 0.85rem;
+}
+
+.app-muted {
+    color: var(--app-muted);
+}
+
+.app-card--compact {
+    padding: 1.5rem;
+}
+
+.app-card--table {
+    padding: 1.5rem 1.5rem 0.75rem 1.5rem;
+}
+
+.app-card--table [data-testid="stDataFrameContainer"] {
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+.app-card--table [data-testid="stStyledDataFrame"] table {
+    border-collapse: collapse !important;
+}
+
+.app-card--table [data-testid="stStyledDataFrame"] tbody tr {
+    border-bottom: 1px solid rgba(81, 69, 205, 0.08);
+}
+
+.app-card--table [data-testid="stStyledDataFrame"] tbody tr:hover {
+    background: rgba(81, 69, 205, 0.05);
+}
+
+.app-checklist {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.65rem;
+}
+
+.app-checklist li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 999px;
+    background: var(--app-accent-soft);
+    color: var(--app-text);
+    font-weight: 600;
+}
+
+.app-checklist__badge {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    background: var(--app-accent);
+    color: white;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.95rem;
+}
+
+.app-question-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.app-question-list__item {
+    padding: 1rem 1.25rem;
+    border-radius: 1rem;
+    background: rgba(81, 69, 205, 0.05);
+    border: 1px solid rgba(81, 69, 205, 0.08);
+}
+
+.app-question-list__meta {
+    font-size: 0.9rem;
+    color: var(--app-muted);
+    margin-top: 0.35rem;
+}
+
+.app-question-list pre {
+    background: rgba(15, 23, 42, 0.85);
+    color: #f9fafb;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    overflow-x: auto;
+}
+
+.stButton>button,
+button[kind="primary"],
+button[data-baseweb="button"] {
+    border-radius: 999px !important;
+    font-weight: 600 !important;
+    padding: 0.6rem 1.6rem !important;
+    border: none !important;
+    background: var(--app-accent) !important;
+    color: #fff !important;
+    box-shadow: 0 10px 30px rgba(81, 69, 205, 0.25) !important;
+}
+
+.stButton>button:hover,
+button[kind="primary"]:hover,
+button[data-baseweb="button"]:hover {
+    background: var(--app-accent-dark) !important;
+    box-shadow: 0 12px 32px rgba(81, 69, 205, 0.35) !important;
+}
+
+.stMetric {
+    background: var(--app-surface);
+    border-radius: 1.25rem;
+    padding: 1.2rem 1.4rem;
+    border: 1px solid rgba(81, 69, 205, 0.1);
+    box-shadow: 0 10px 26px rgba(15, 23, 42, 0.06);
+}
+
+.stMetric label {
+    color: var(--app-muted) !important;
+    font-weight: 600 !important;
+}
+
+.stAlert {
+    border-radius: 1.25rem;
+    border: 1px solid rgba(81, 69, 205, 0.18);
+}
+
+.questionnaire-intro {
+    background: linear-gradient(135deg, rgba(81, 69, 205, 0.12), rgba(129, 212, 250, 0.18));
+    padding: 1.75rem;
+    border-radius: 1.5rem;
+    border: 1px solid rgba(81, 69, 205, 0.18);
+    margin-bottom: 1.5rem;
+}
+
+.questionnaire-intro h2 {
+    margin: 0 0 0.75rem 0;
+}
+
+.questionnaire-intro p {
+    margin-bottom: 0.75rem;
+    color: var(--app-muted);
+}
+
+.question-card {
+    padding: 1.5rem 1.75rem 1.75rem 1.75rem;
+    border-radius: 1.5rem;
+    background: var(--app-surface-strong);
+    border: 1px solid rgba(81, 69, 205, 0.12);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.07);
+    margin-bottom: 1.25rem;
+}
+
+.question-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+}
+
+.question-header h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--app-text);
+}
+
+.question-step {
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: var(--app-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.question-help {
+    color: var(--app-muted);
+    font-size: 0.95rem;
+    margin-bottom: 0.75rem;
+}
+
+[data-testid="stExpander"] {
+    border-radius: 1.5rem;
+    border: 1px solid rgba(81, 69, 205, 0.12);
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.06);
+}
+
+[data-testid="stExpander"] [data-testid="stMarkdown"] p {
+    color: var(--app-muted);
+}
+</style>
+"""
+
+
+def apply_app_theme(page_title: str, page_icon: Optional[str] = None) -> None:
+    """Set up consistent page configuration and inject the shared CSS theme."""
+
+    st.set_page_config(
+        page_title=page_title,
+        page_icon=page_icon,
+        layout="wide",
+        initial_sidebar_state="expanded",
+    )
+    st.markdown(_THEME_CSS, unsafe_allow_html=True)
+
+
+def page_header(
+    title: str,
+    subtitle: Optional[str] = None,
+    icon: Optional[str] = None,
+    *,
+    container: Optional[Any] = None,
+) -> None:
+    """Render a hero-style header with a title, subtitle, and optional icon."""
+
+    icon_markup = f"<span class='app-header__icon'>{icon}</span>" if icon else ""
+    subtitle_markup = (
+        f"<p class='app-header__subtitle'>{subtitle}</p>" if subtitle else ""
+    )
+    target = container.markdown if container is not None else st.markdown
+    target(
+        f"""
+        <div class="app-header">
+            {icon_markup}
+            <div>
+                <h1 class="app-header__title">{title}</h1>
+                {subtitle_markup}
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_card(content: str, title: Optional[str] = None, *, compact: bool = False, table: bool = False) -> None:
+    """Render pre-formatted HTML content inside a themed surface."""
+
+    classes = ["app-card"]
+    if compact:
+        classes.append("app-card--compact")
+    if table:
+        classes.append("app-card--table")
+    class_attr = " ".join(classes)
+    heading = f"<h3 class='app-card__title'>{title}</h3>" if title else ""
+    st.markdown(
+        f"<div class='{class_attr}'>{heading}{content}</div>",
+        unsafe_allow_html=True,
+    )

--- a/pages/02_Editor.py
+++ b/pages/02_Editor.py
@@ -22,6 +22,7 @@ from Home import load_schema
 from lib.github_backend import GitHubBackend, create_branch, ensure_pr, put_file
 from lib.form_store import load_combined_schema, local_form_path, resolve_remote_form_path
 import lib.questionnaire_utils as questionnaire_utils
+from lib.ui_theme import apply_app_theme, page_header
 
 EDITOR_SELECTED_STATE_KEY = questionnaire_utils.EDITOR_SELECTED_STATE_KEY
 normalize_questionnaires = questionnaire_utils.normalize_questionnaires
@@ -2648,10 +2649,14 @@ def render_add_question(schema: Dict[str, Any]) -> None:
 def main() -> None:
     """Render the questionnaire editor page."""
 
+    apply_app_theme(page_title="Questionnaire editor", page_icon="🛠️")
     require_authentication()
 
-    st.title("Questionnaire editor")
-    st.caption("Authentication is assumed to have already succeeded.")
+    page_header(
+        "Questionnaire editor",
+        "Authentication is assumed to have already succeeded.",
+        icon="🛠️",
+    )
 
     schema = get_schema()
     questionnaires = schema.get("questionnaires", {})

--- a/pages/03_Registered_Systems.py
+++ b/pages/03_Registered_Systems.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Iterable, List, Tuple
 import streamlit as st
 
 from lib import questionnaire_utils
+from lib.ui_theme import apply_app_theme, page_header
 
 RECORD_NAME_KEY = getattr(questionnaire_utils, "RECORD_NAME_KEY", "record_name")
 
@@ -103,12 +104,11 @@ def _strip_private_keys(records: Iterable[Dict[str, Any]]) -> List[Dict[str, Any
     return cleaned
 
 
-st.set_page_config(page_title="Registered systems", page_icon="📋")
-st.title("Registered systems")
-
-st.write(
-    "Browse the systems registered through the questionnaire. "
-    "Duplicate submissions are grouped by their identifier, showing the most recent entry."
+apply_app_theme(page_title="Registered systems", page_icon="📋")
+page_header(
+    "Registered systems",
+    "Browse the systems registered through the questionnaire. Duplicate submissions are grouped by their identifier, showing the most recent entry.",
+    icon="📋",
 )
 
 submissions = _load_submissions(SUBMISSIONS_DIR)
@@ -116,12 +116,26 @@ submissions = _load_submissions(SUBMISSIONS_DIR)
 if not submissions:
     st.info("No system registration submissions found yet.")
 else:
+    unique_questionnaires = {
+        str(record.get("Questionnaire", ""))
+        for record in submissions
+        if str(record.get("Questionnaire", ""))
+    }
+    most_recent = submissions[0].get("Submitted at", "—")
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Total submissions", len(submissions))
+    col2.metric("Questionnaires", len(unique_questionnaires) or "—")
+    col3.metric("Most recent submission", most_recent or "—")
+
     columns = _table_columns(submissions)
     table_rows = _strip_private_keys(submissions)
-    st.dataframe(
-        table_rows,
-        width="stretch",
-        hide_index=True,
-        column_order=columns,
-    )
+    with st.container():
+        st.markdown("<div class='app-card app-card--table'>", unsafe_allow_html=True)
+        st.dataframe(
+            table_rows,
+            width="stretch",
+            hide_index=True,
+            column_order=columns,
+        )
+        st.markdown("</div>", unsafe_allow_html=True)
 

--- a/pages/04_Assessment_Submissions.py
+++ b/pages/04_Assessment_Submissions.py
@@ -15,6 +15,7 @@ if str(PROJECT_ROOT) not in sys.path:
 import streamlit as st
 
 from lib import questionnaire_utils
+from lib.ui_theme import apply_app_theme, page_header
 
 RECORD_NAME_KEY = getattr(questionnaire_utils, "RECORD_NAME_KEY", "record_name")
 
@@ -108,12 +109,11 @@ def _strip_private_keys(records: Iterable[Dict[str, Any]]) -> List[Dict[str, Any
     return cleaned
 
 
-st.set_page_config(page_title="Assessment submissions", page_icon="📝")
-st.title("Assessment submissions")
-
-st.write(
-    "Browse the assessment responses submitted through the questionnaire. "
-    "Duplicate submissions are grouped by their identifier, showing the most recent entry."
+apply_app_theme(page_title="Assessment submissions", page_icon="📝")
+page_header(
+    "Assessment submissions",
+    "Browse the assessment responses submitted through the questionnaire. Duplicate submissions are grouped by their identifier, showing the most recent entry.",
+    icon="📝",
 )
 
 submissions = _load_submissions(SUBMISSIONS_DIR)
@@ -121,11 +121,25 @@ submissions = _load_submissions(SUBMISSIONS_DIR)
 if not submissions:
     st.info("No assessment submissions found yet.")
 else:
+    unique_questionnaires = {
+        str(record.get("Questionnaire", ""))
+        for record in submissions
+        if str(record.get("Questionnaire", ""))
+    }
+    most_recent = submissions[0].get("Submitted at", "—")
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Total submissions", len(submissions))
+    col2.metric("Questionnaires", len(unique_questionnaires) or "—")
+    col3.metric("Most recent submission", most_recent or "—")
+
     columns = _table_columns(submissions)
     table_rows = _strip_private_keys(submissions)
-    st.dataframe(
-        table_rows,
-        width="stretch",
-        hide_index=True,
-        column_order=columns,
-    )
+    with st.container():
+        st.markdown("<div class='app-card app-card--table'>", unsafe_allow_html=True)
+        st.dataframe(
+            table_rows,
+            width="stretch",
+            hide_index=True,
+            column_order=columns,
+        )
+        st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- introduce a shared UI theme utility that applies a cohesive palette, typography, and card styling across Streamlit pages
- update the Home and questionnaire experiences with hero headers, checklists, and richer question summaries that match the refreshed identity
- restyle the editor and submission review pages with consistent headers, metrics, and themed data tables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc403dbc6c832195b36ab729fd0c0b