### PR TITLE
Fix invalid return statements in Streamlit pages

### DIFF
--- a/pages/03_Registered_Systems.py
+++ b/pages/03_Registered_Systems.py
@@ -410,7 +410,7 @@ else:
             payload = selected.get("_raw_payload", {})
             if not isinstance(payload, dict):
                 st.error("Submission payload is not a JSON object and cannot be edited visually.")
-                return
+                st.stop()
 
             answers = payload.get("answers", {})
             if not isinstance(answers, dict):

--- a/pages/04_Assessment_Submissions.py
+++ b/pages/04_Assessment_Submissions.py
@@ -361,7 +361,7 @@ else:
             payload = selected.get("_raw_payload", {})
             if not isinstance(payload, dict):
                 st.error("Submission payload is not a JSON object and cannot be edited visually.")
-                return
+                st.stop()
 
             answers = payload.get("answers", {})
             if not isinstance(answers, dict):


### PR DESCRIPTION
## Summary
- replace top-level return statements in the registered systems and assessment submissions pages with `st.stop()` so the scripts no longer raise syntax errors when encountering invalid payloads

## Testing
- python -m compileall pages/03_Registered_Systems.py pages/04_Assessment_Submissions.py

------
https://chatgpt.com/codex/tasks/task_e_68dc521235748321b2ff602b41b203f0