### PR TITLE
Ensure managed deletions remove duplicate submissions

### DIFF
--- a/lib/submission_storage.py
+++ b/lib/submission_storage.py
@@ -1,0 +1,82 @@
+"""Utilities for working with stored questionnaire submission files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+
+def delete_submission_files(
+    submission_id: str,
+    directory: Path,
+    *,
+    skip_paths: Sequence[Path] | None = None,
+) -> Tuple[List[Path], List[Path]]:
+    """Delete files in ``directory`` matching ``submission_id``.
+
+    Parameters
+    ----------
+    submission_id:
+        The identifier associated with the submission.
+    directory:
+        The directory where submission JSON files are stored.
+    skip_paths:
+        Optional paths that should not be deleted. These are typically files that
+        have already been removed (to avoid repeated work) or ones that should be
+        preserved.
+
+    Returns
+    -------
+    Tuple[List[Path], List[Path]]
+        Two lists containing the paths that were successfully removed and the
+        ones that could not be deleted because of an ``OSError``.
+    """
+
+    normalized_id = str(submission_id or "").strip()
+    if not normalized_id or not directory.exists():
+        return [], []
+
+    skipped: set[Path] = set()
+    if skip_paths:
+        for item in skip_paths:
+            try:
+                skipped.add(Path(item).resolve())
+            except OSError:
+                skipped.add(Path(item))
+
+    removed: List[Path] = []
+    failed: List[Path] = []
+
+    for candidate in directory.glob("*.json"):
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        if resolved in skipped:
+            continue
+
+        matches = candidate.stem == normalized_id
+        if not matches:
+            try:
+                with candidate.open("r", encoding="utf-8") as handle:
+                    payload = json.load(handle)
+            except (OSError, json.JSONDecodeError):
+                continue
+            candidate_id = str(payload.get("id") or "").strip()
+            matches = candidate_id == normalized_id
+
+        if not matches:
+            continue
+
+        try:
+            candidate.unlink()
+        except OSError:
+            failed.append(candidate)
+        else:
+            removed.append(candidate)
+
+    return removed, failed
+
+
+__all__ = ["delete_submission_files"]

--- a/pages/04_Assessment_Submissions.py
+++ b/pages/04_Assessment_Submissions.py
@@ -17,6 +17,7 @@ import streamlit as st
 
 from lib import questionnaire_utils
 from lib.ui_theme import apply_app_theme, page_header
+from lib.submission_storage import delete_submission_files
 
 RECORD_NAME_KEY = getattr(questionnaire_utils, "RECORD_NAME_KEY", "record_name")
 
@@ -468,11 +469,27 @@ else:
                 if st.button("Delete submission", type="secondary"):
                     path = selected.get("_path")
                     if isinstance(path, Path):
+                        submission_id = str(selected.get("Submission ID") or "").strip()
                         try:
                             path.unlink()
                         except OSError as exc:
                             st.error(f"Failed to delete submission: {exc}.")
                         else:
+                            removed_extra, failed_extra = [], []
+                            if submission_id:
+                                removed_extra, failed_extra = delete_submission_files(
+                                    submission_id,
+                                    SUBMISSIONS_DIR,
+                                    skip_paths=[path],
+                                )
+
+                            if failed_extra:
+                                failed_names = ", ".join(candidate.name for candidate in failed_extra)
+                                st.warning(
+                                    "Deleted the selected submission but failed to remove "
+                                    f"additional copies: {failed_names}."
+                                )
+
                             st.success("Submission deleted successfully.")
                             st.session_state.pop(MANAGED_SUBMISSION_KEY, None)
                             _set_query_param(SUBMISSION_ID_PARAM, None)


### PR DESCRIPTION
## Summary
- add a shared helper for removing all stored files tied to a submission identifier
- update the system and assessment management pages to delete every copy of a submission when managed from the UI and warn on failures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc532a4d4c8321989048f28aa0c68f