### PR TITLE
Add risk identification module to questionnaire editor

### DIFF
--- a/lib/questionnaire_utils.py
+++ b/lib/questionnaire_utils.py
@@ -77,11 +77,13 @@ def normalize_questionnaires(schema: Dict[str, Any]) -> Dict[str, Dict[str, Any]
     if not isinstance(questionnaires, dict) or not questionnaires:
         page_settings = _ensure_mapping(schema.get("page"))
         questions = _ensure_sequence(schema.get("questions"))
+        risks = _ensure_sequence(schema.get("risks"))
         questionnaires = {
             DEFAULT_QUESTIONNAIRE_KEY: {
                 "label": _derive_label(DEFAULT_QUESTIONNAIRE_KEY, {"page": page_settings}),
                 "page": page_settings,
                 "questions": questions,
+                "risks": risks,
             }
         }
 
@@ -90,12 +92,14 @@ def normalize_questionnaires(schema: Dict[str, Any]) -> Dict[str, Dict[str, Any]
         entry = _ensure_mapping(payload).copy()
         entry["page"] = _ensure_mapping(entry.get("page"))
         entry["questions"] = _ensure_sequence(entry.get("questions"))
+        entry["risks"] = _ensure_sequence(entry.get("risks"))
         entry["label"] = _derive_label(key, entry)
         normalised[str(key)] = entry
 
     schema["questionnaires"] = normalised
     schema.pop("page", None)
     schema.pop("questions", None)
+    schema.pop("risks", None)
     return normalised
 
 


### PR DESCRIPTION
## Summary
- add a risk management workflow to the editor, including overview, editing, and a logic builder that mirrors the question rule experience
- persist risk definitions by normalizing questionnaire schemas and validating risk keys, levels, and referenced question fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc565fbe208321b7610af89016b473