### PR TITLE
Link assessment risks to system overviews

### DIFF
--- a/lib/risk_display.py
+++ b/lib/risk_display.py
@@ -1,0 +1,157 @@
+"""Helpers for presenting risk assignments consistently across pages."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any, Dict, List, Tuple
+
+
+RISK_LEVEL_EMOJIS: Dict[str, Tuple[str, str]] = {
+    "limited": ("🟢", "Limited"),
+    "high": ("🟠", "High"),
+    "unacceptable": ("🔴", "Unacceptable"),
+}
+
+RISK_BADGE_CLASSES: Dict[str, str] = {
+    "limited": "app-risk-badge--limited",
+    "high": "app-risk-badge--high",
+    "unacceptable": "app-risk-badge--unacceptable",
+}
+
+
+def _clean_text(value: Any) -> str:
+    """Return ``value`` converted to a trimmed string."""
+
+    if isinstance(value, str):
+        return value.strip()
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _ensure_sequence(value: Any) -> Sequence[Any]:
+    """Return a safe sequence representation of ``value``."""
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return value
+    if value is None:
+        return []
+    return [value]
+
+
+def normalise_risk_entries(risks: Any) -> List[Dict[str, Any]]:
+    """Return risk entries in a consistent, presentation-friendly form."""
+
+    normalised: List[Dict[str, Any]] = []
+    for entry in _ensure_sequence(risks):
+        if not isinstance(entry, dict):
+            continue
+
+        key = _clean_text(entry.get("key"))
+        name = _clean_text(entry.get("name"))
+        level_raw = _clean_text(entry.get("level"))
+        level = level_raw.lower()
+        level_label = level_raw.title() if level_raw else "Unknown"
+        system_id = _clean_text(entry.get("system_id"))
+        mitigations = [
+            _clean_text(item)
+            for item in _ensure_sequence(entry.get("mitigations"))
+            if _clean_text(item)
+        ]
+
+        display_name = name or key or "Risk"
+        record: Dict[str, Any] = {
+            "name": display_name,
+            "level": level,
+            "level_label": level_label,
+        }
+        if key:
+            record["key"] = key
+        if system_id:
+            record["system_id"] = system_id
+        if mitigations:
+            record["mitigations"] = mitigations
+
+        normalised.append(record)
+
+    return normalised
+
+
+def aggregate_risks_for_system(
+    assessments: Iterable[Dict[str, Any]], system_id: str
+) -> List[Dict[str, Any]]:
+    """Return unique risks assigned to ``system_id`` from ``assessments``."""
+
+    target_id = _clean_text(system_id)
+    aggregated: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
+
+    for assessment in assessments:
+        if not isinstance(assessment, dict):
+            continue
+
+        assessment_system = _clean_text(assessment.get("system_id"))
+        for risk in normalise_risk_entries(assessment.get("risks")):
+            risk_system = _clean_text(risk.get("system_id")) or assessment_system or target_id
+            if target_id and risk_system and risk_system != target_id:
+                continue
+
+            dedup_key = (
+                risk.get("key") or risk.get("name"),
+                risk.get("level", ""),
+                risk_system,
+            )
+
+            risk_copy = dict(risk)
+            if risk_system:
+                risk_copy["system_id"] = risk_system
+
+            aggregated.setdefault(dedup_key, risk_copy)
+
+    return list(aggregated.values())
+
+
+def risks_to_markdown(risks: Iterable[Dict[str, Any]]) -> str:
+    """Return a newline-separated summary of ``risks`` with colour icons."""
+
+    lines: List[str] = []
+    for risk in normalise_risk_entries(list(risks)):
+        emoji, default_label = RISK_LEVEL_EMOJIS.get(
+            risk.get("level", ""), ("⚪", "Unknown")
+        )
+        label = risk.get("level_label") or default_label
+        lines.append(f"{emoji} {label} · {risk.get('name')}")
+
+    return "\n".join(lines)
+
+
+def risks_to_badges_html(risks: Iterable[Dict[str, Any]]) -> str:
+    """Return HTML markup representing ``risks`` as styled badges."""
+
+    entries = normalise_risk_entries(list(risks))
+    if not entries:
+        return ""
+
+    badges: List[str] = []
+    for risk in entries:
+        css_class = RISK_BADGE_CLASSES.get(
+            risk.get("level", ""), "app-risk-badge--unknown"
+        )
+        level_label = risk.get("level_label") or "Unknown"
+        name = risk.get("name") or "Risk"
+        badge = (
+            "<span class='app-risk-badge {css}'>"
+            "<span class='app-risk-badge__level'>{level}</span>"
+            "<span class='app-risk-badge__name'>{name}</span>"
+            "</span>"
+        ).format(css=css_class, level=level_label, name=name)
+        badges.append(badge)
+
+    return "<div class='app-risk-badges'>" + "".join(badges) + "</div>"
+
+
+__all__ = [
+    "aggregate_risks_for_system",
+    "normalise_risk_entries",
+    "risks_to_badges_html",
+    "risks_to_markdown",
+]

--- a/lib/ui_theme.py
+++ b/lib/ui_theme.py
@@ -193,6 +193,55 @@ html, body {
     overflow-x: auto;
 }
 
+.app-risk-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.35rem;
+}
+
+.app-risk-badge {
+    display: inline-flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    letter-spacing: 0.01em;
+    color: white;
+    background: var(--app-muted);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+}
+
+.app-risk-badge__level {
+    text-transform: uppercase;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    opacity: 0.9;
+}
+
+.app-risk-badge__name {
+    font-size: 0.9rem;
+}
+
+.app-risk-badge--limited {
+    background: var(--app-success);
+}
+
+.app-risk-badge--high {
+    background: var(--app-warning);
+}
+
+.app-risk-badge--unacceptable {
+    background: var(--app-error);
+}
+
+.app-risk-badge--unknown {
+    background: var(--app-muted);
+}
+
 .stButton>button,
 button[kind="primary"],
 button[data-baseweb="button"] {

--- a/tests/test_assessment_submission.py
+++ b/tests/test_assessment_submission.py
@@ -64,6 +64,96 @@ def test_store_assessment_submission_success(monkeypatch):
     assert errors == []
 
 
+def test_store_assessment_submission_assigns_risks(monkeypatch):
+    """Triggered risks should be stored with the assessment submission."""
+
+    import importlib
+
+    questionnaire = importlib.import_module("pages.01_Questionnaire")
+
+    captured = {}
+
+    class DummyBackend:
+        def __init__(
+            self,
+            *,
+            token: str,
+            repo: str,
+            path: str,
+            branch: str = "main",
+            api_url: str = "https://api.github.com",
+        ) -> None:
+            captured["init"] = {
+                "token": token,
+                "repo": repo,
+                "path": path,
+                "branch": branch,
+                "api_url": api_url,
+            }
+
+        def write_json(self, data, message):
+            captured["payload"] = data
+            captured["message"] = message
+            return {"ok": True}
+
+    settings = {
+        "token": "secret-token",
+        "repo": "example/repo",
+        "branch": "main",
+        "api_url": "https://enterprise.example/api/v3",
+        "assessment_submissions_path": "assessments/{submission_id}.json",
+    }
+
+    dummy_uuid = SimpleNamespace(hex="abc999")
+
+    sample_schema = {
+        "questionnaires": {
+            "assessment": {
+                "questions": [],
+                "risks": [
+                    {
+                        "key": "demo-risk",
+                        "name": "Demonstration risk",
+                        "level": "high",
+                        "logic": {
+                            "field": "flag",
+                            "operator": "equals",
+                            "value": "yes",
+                        },
+                        "mitigations": ["Document controls"],
+                    }
+                ],
+            }
+        }
+    }
+
+    monkeypatch.setattr(questionnaire, "GitHubBackend", DummyBackend)
+    monkeypatch.setattr(questionnaire, "_github_settings", lambda: settings)
+    monkeypatch.setattr(questionnaire.uuid, "uuid4", lambda: dummy_uuid)
+    monkeypatch.setattr(questionnaire, "load_schema", lambda: sample_schema)
+
+    errors = []
+    monkeypatch.setattr(questionnaire.st, "error", lambda message: errors.append(message))
+
+    answers = {"flag": "yes", "related-sytem": "sys-123"}
+    submission_id = questionnaire.store_assessment_submission(dict(answers))
+
+    assert submission_id == "abc999"
+    payload = captured.get("payload")
+    assert payload is not None
+    assert payload["related_system_id"] == "sys-123"
+    assert payload["risks"] == [
+        {
+            "key": "demo-risk",
+            "name": "Demonstration risk",
+            "level": "high",
+            "mitigations": ["Document controls"],
+            "system_id": "sys-123",
+        }
+    ]
+    assert errors == []
+
+
 def test_store_assessment_submission_missing_github(monkeypatch):
     """If GitHub configuration is missing the assessment should not be stored."""
 

--- a/tests/test_risk_display.py
+++ b/tests/test_risk_display.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_normalise_risk_entries_standardises_fields() -> None:
+    module = importlib.import_module("lib.risk_display")
+
+    entries = module.normalise_risk_entries(
+        {"name": "Privacy", "level": "High", "system_id": "sys-1"}
+    )
+
+    assert entries == [
+        {
+            "name": "Privacy",
+            "level": "high",
+            "level_label": "High",
+            "system_id": "sys-1",
+        }
+    ]
+
+
+def test_aggregate_risks_for_system_filters_and_deduplicates() -> None:
+    module = importlib.import_module("lib.risk_display")
+
+    assessments = [
+        {"system_id": "alpha", "risks": [{"key": "r1", "level": "high", "name": "One"}]},
+        {"system_id": "beta", "risks": [{"key": "r1", "level": "high", "name": "One"}]},
+        {"system_id": "alpha", "risks": [{"key": "r2", "level": "limited", "name": "Two"}]},
+        {"system_id": "alpha", "risks": [{"key": "r1", "level": "high", "name": "One"}]},
+    ]
+
+    aggregated = module.aggregate_risks_for_system(assessments, "alpha")
+
+    assert {risk["key"] for risk in aggregated} == {"r1", "r2"}
+    assert {risk.get("system_id") for risk in aggregated} == {"alpha"}
+
+
+def test_risks_to_markdown_adds_colour_icons() -> None:
+    module = importlib.import_module("lib.risk_display")
+
+    text = module.risks_to_markdown(
+        [
+            {
+                "name": "Critical",
+                "level": "unacceptable",
+                "level_label": "Unacceptable",
+            }
+        ]
+    )
+
+    assert "🔴" in text
+    assert "Critical" in text


### PR DESCRIPTION
## Summary
- evaluate configured risks when an assessment is stored so the payload records triggered risks and the related system
- add reusable helpers and styling for rendering color-coded risk badges
- surface each system's assigned risks on the home dashboard and registered systems management page

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcadcfa3bc8321b0b639c8ca5065ca