### PR TITLE
Fix risk submission for legacy logic definitions

### DIFF
--- a/pages/01_Questionnaire.py
+++ b/pages/01_Questionnaire.py
@@ -295,6 +295,8 @@ def _collect_triggered_risks(
             continue
 
         logic = risk.get("logic")
+        if isinstance(logic, Sequence) and not isinstance(logic, (str, bytes, dict)):
+            logic = {"all": list(logic)}
         if logic is None:
             continue
         if not isinstance(logic, dict):

--- a/tests/test_assessment_submission.py
+++ b/tests/test_assessment_submission.py
@@ -154,6 +154,93 @@ def test_store_assessment_submission_assigns_risks(monkeypatch):
     assert errors == []
 
 
+def test_store_assessment_submission_supports_list_logic(monkeypatch):
+    """Legacy risk logic defined as lists should still trigger risks."""
+
+    import importlib
+
+    questionnaire = importlib.import_module("pages.01_Questionnaire")
+
+    captured = {}
+
+    class DummyBackend:
+        def __init__(
+            self,
+            *,
+            token: str,
+            repo: str,
+            path: str,
+            branch: str = "main",
+            api_url: str = "https://api.github.com",
+        ) -> None:
+            captured["init"] = {
+                "token": token,
+                "repo": repo,
+                "path": path,
+                "branch": branch,
+                "api_url": api_url,
+            }
+
+        def write_json(self, data, message):
+            captured["payload"] = data
+            captured["message"] = message
+            return {"ok": True}
+
+    settings = {
+        "token": "secret-token",
+        "repo": "example/repo",
+        "branch": "main",
+        "api_url": "https://enterprise.example/api/v3",
+        "assessment_submissions_path": "assessments/{submission_id}.json",
+    }
+
+    dummy_uuid = SimpleNamespace(hex="abc123")
+
+    legacy_schema = {
+        "questionnaires": {
+            "assessment": {
+                "questions": [],
+                "risks": [
+                    {
+                        "key": "legacy-risk",
+                        "name": "Legacy risk",
+                        "level": "limited",
+                        "logic": [
+                            {
+                                "field": "legacy",
+                                "operator": "equals",
+                                "value": "trigger",
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+    }
+
+    monkeypatch.setattr(questionnaire, "GitHubBackend", DummyBackend)
+    monkeypatch.setattr(questionnaire, "_github_settings", lambda: settings)
+    monkeypatch.setattr(questionnaire.uuid, "uuid4", lambda: dummy_uuid)
+    monkeypatch.setattr(questionnaire, "load_schema", lambda: legacy_schema)
+
+    errors = []
+    monkeypatch.setattr(questionnaire.st, "error", lambda message: errors.append(message))
+
+    submission_id = questionnaire.store_assessment_submission({"legacy": "trigger"})
+
+    assert submission_id == "abc123"
+    payload = captured.get("payload")
+    assert payload is not None
+    assert payload.get("risks") == [
+        {
+            "key": "legacy-risk",
+            "name": "Legacy risk",
+            "level": "limited",
+        }
+    ]
+    assert errors == []
+
+
 def test_store_assessment_submission_missing_github(monkeypatch):
     """If GitHub configuration is missing the assessment should not be stored."""
 


### PR DESCRIPTION
## Summary
- normalise legacy list-based risk logic into dictionaries before evaluation so triggered risks are persisted
- add a regression test covering assessment submissions with list-style risk logic definitions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcb5a90f8883219713b53d4151bb83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy risk logic defined as lists/tuples. Such logic is now normalized and evaluated consistently, ensuring these risks trigger correctly and appear in stored assessment submissions.
  * Enhances reliability of risk detection and payload generation without changing user workflow.

* **Tests**
  * Added coverage to verify that list-based risk logic triggers as expected and is included in submission payloads, preventing regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->