### PR TITLE
Simplify questionnaire question layout

### DIFF
--- a/lib/ui_theme.py
+++ b/lib/ui_theme.py
@@ -296,114 +296,48 @@ button[data-baseweb="button"]:hover {
     color: var(--app-muted);
 }
 
-.question-card {
-    padding: 1.75rem;
-    border-radius: 1.5rem;
-    background: var(--app-surface-strong);
-    border: 1px solid rgba(81, 69, 205, 0.12);
-    box-shadow: 0 20px 38px rgba(15, 23, 42, 0.08);
+
+.question-block {
     margin-bottom: 1.5rem;
+    padding: 1.5rem;
+    border-radius: 1.25rem;
+    background: var(--app-surface-strong);
+    border: 1px solid rgba(81, 69, 205, 0.15);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.question-block__header {
     display: flex;
     flex-direction: column;
-    gap: 1.1rem;
+    gap: 0.35rem;
 }
 
-.question-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
+.question-block__step {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--app-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
-.question-header h3 {
+.question-block__title {
     margin: 0;
-    font-size: 1.2rem;
+    font-size: 1.18rem;
     font-weight: 600;
     color: var(--app-text);
     line-height: 1.4;
 }
 
-.question-step {
-    font-size: 0.8rem;
-    font-weight: 700;
+.question-block__title sup {
     color: var(--app-accent);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    background: rgba(81, 69, 205, 0.12);
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
+    margin-left: 0.2rem;
+    font-size: 0.85rem;
 }
 
-.question-help {
+.question-block__help {
+    margin: 0.25rem 0 0 0;
     color: var(--app-muted);
     font-size: 0.95rem;
-    margin: 0;
-}
-
-.question-card .stMarkdown p:last-child {
-    margin-bottom: 0;
-}
-
-.question-card [data-baseweb="radio"] {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.question-card [data-baseweb="radio"] label,
-.question-card [data-baseweb="checkbox"] label {
-    background: rgba(81, 69, 205, 0.08);
-    border-radius: 0.95rem;
-    border: 1px solid rgba(81, 69, 205, 0.15);
-    padding: 0.65rem 0.85rem;
-    transition: all 0.2s ease;
-}
-
-.question-card [data-baseweb="radio"] label:hover,
-.question-card [data-baseweb="checkbox"] label:hover {
-    border-color: rgba(81, 69, 205, 0.45);
-    background: rgba(81, 69, 205, 0.14);
-}
-
-.question-card [data-testid="stCheckbox"] > label {
-    display: flex;
-    align-items: center;
-    gap: 0.55rem;
-}
-
-.question-card [data-testid="stSelectbox"],
-.question-card [data-testid="stMultiSelect"] {
-    background: rgba(81, 69, 205, 0.05);
-    border-radius: 1rem;
-    padding: 0.5rem 0.65rem;
-    border: 1px solid rgba(81, 69, 205, 0.18);
-}
-
-.question-card [data-baseweb="select"] {
-    background: transparent;
-}
-
-.question-card input,
-.question-card textarea {
-    border-radius: 0.85rem !important;
-    border: 1px solid rgba(81, 69, 205, 0.25) !important;
-    background: rgba(255, 255, 255, 0.92) !important;
-    padding: 0.65rem 0.85rem !important;
-}
-
-.question-card input:focus,
-.question-card textarea:focus {
-    border-color: rgba(81, 69, 205, 0.55) !important;
-    box-shadow: 0 0 0 0.25rem rgba(81, 69, 205, 0.1);
-}
-
-.question-card .stCaption,
-.question-card [data-testid="stCaption"] {
-    color: var(--app-muted);
-}
-
-.question-card .stAlert {
-    margin-bottom: 0;
 }
 
 [data-testid="stExpander"] {

--- a/pages/01_Questionnaire.py
+++ b/pages/01_Questionnaire.py
@@ -726,30 +726,27 @@ def render_question(
     else:
         question_intro = f"Question {index + 1} of {total}"
 
-    card = st.container()
-    card.markdown(
-        "<div class='question-card'>",
-        unsafe_allow_html=True,
-    )
-    card.markdown(
+    question_block = st.container()
+    question_block.markdown(
         f"""
-        <div class="question-header">
-            <span class="question-step">{question_intro}</span>
-            <h3>{label}{' *' if required else ''}</h3>
-        </div>
-        {f'<p class="question-help">{help_text}</p>' if help_text else ''}
+        <section class="question-block">
+            <div class="question-block__header">
+                <span class="question-block__step">{question_intro}</span>
+                <h3 class="question-block__title">{label}{'<sup>*</sup>' if required else ''}</h3>
+            </div>
+            {f'<p class="question-block__help">{help_text}</p>' if help_text else ''}
         """,
         unsafe_allow_html=True,
     )
 
-    def _close_card() -> None:
-        card.markdown("</div>", unsafe_allow_html=True)
+    def _close_block() -> None:
+        question_block.markdown("</section>", unsafe_allow_html=True)
 
     if question_type == "single":
         options: List[str] = [option for option in question.get("options", []) if isinstance(option, str)]
         if not options:
-            card.warning(f"Question '{question_key}' has no options configured.")
-            _close_card()
+            question_block.warning(f"Question '{question_key}' has no options configured.")
+            _close_block()
             return
         choices = [UNSELECTED_LABEL, *options]
         if widget_key in st.session_state and st.session_state[widget_key] not in choices:
@@ -760,7 +757,7 @@ def render_question(
                 default_value if isinstance(default_value, str) and default_value in options else UNSELECTED_LABEL
             )
         index = choices.index(default_choice)
-        selection = card.radio(
+        selection = question_block.radio(
             label,
             choices,
             index=index,
@@ -774,8 +771,8 @@ def render_question(
     elif question_type == "multiselect":
         options = [option for option in question.get("options", []) if isinstance(option, str)]
         if not options:
-            card.warning(f"Question '{question_key}' has no options configured.")
-            _close_card()
+            question_block.warning(f"Question '{question_key}' has no options configured.")
+            _close_block()
             return
         if isinstance(default_value, list):
             default_selection = [value for value in default_value if value in options]
@@ -783,7 +780,7 @@ def render_question(
             default_selection = [value for value in question.get("default", []) if value in options]
         else:
             default_selection = []
-        selections = card.multiselect(
+        selections = question_block.multiselect(
             label,
             options=options,
             default=default_selection,
@@ -793,7 +790,7 @@ def render_question(
         answers[question_key] = selections
     elif question_type == "bool":
         default_bool = bool(default_value) if default_value is not None else False
-        selection = card.checkbox(
+        selection = question_block.checkbox(
             label,
             value=default_bool,
             key=widget_key,
@@ -802,7 +799,7 @@ def render_question(
         answers[question_key] = selection
     elif question_type in {"text", RECORD_NAME_TYPE}:
         default_text = "" if default_value is None else str(default_value)
-        text_value = card.text_input(
+        text_value = question_block.text_input(
             label,
             value=default_text,
             key=widget_key,
@@ -822,10 +819,10 @@ def render_question(
             answers.pop(question_key, None)
             if widget_key in st.session_state:
                 st.session_state.pop(widget_key)
-            card.warning(
+            question_block.warning(
                 "Related record questions require a valid source. Contact the questionnaire maintainer."
             )
-            _close_card()
+            _close_block()
             return
 
         options = load_related_record_options(source_key)
@@ -833,10 +830,10 @@ def render_question(
             answers.pop(question_key, None)
             if widget_key in st.session_state:
                 st.session_state.pop(widget_key)
-            card.info(
+            question_block.info(
                 f"No records available for {related_record_source_label(source_key)} yet."
             )
-            _close_card()
+            _close_block()
             return
 
         option_values = [value for value, _ in options]
@@ -853,7 +850,7 @@ def render_question(
         else:
             default_option = UNSELECTED_LABEL
         index = choices.index(default_option)
-        selection = card.selectbox(
+        selection = question_block.selectbox(
             label,
             options=choices,
             index=index,
@@ -867,16 +864,16 @@ def render_question(
             answers.pop(question_key, None)
         else:
             answers[question_key] = selection
-            card.caption(f"Selected record ID: `{selection}`")
+            question_block.caption(f"Selected record ID: `{selection}`")
     elif question_type == "statement":
         answers.pop(question_key, None)
         if widget_key in st.session_state:
             st.session_state.pop(widget_key)
-        card.caption("No response required.")
+        question_block.caption("No response required.")
     else:
-        card.warning(f"Unsupported question type: {question_type}")
+        question_block.warning(f"Unsupported question type: {question_type}")
 
-    _close_card()
+    _close_block()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- replace the question "card" wrapper with a streamlined question block container that works cleanly with the existing rendering pipeline
- update the questionnaire theme to remove per-widget overrides and introduce lightweight styling for the new question block header and help text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd07c8e1108321bc804bc06a7fe487